### PR TITLE
activate progress for connect account + fix css

### DIFF
--- a/backend/src/InputType/programType.ts
+++ b/backend/src/InputType/programType.ts
@@ -5,6 +5,7 @@ export enum ProgramStatus {
   DRAFT = "DRAFT",
   PUBLISHED = "PUBLISHED",
   ARCHIVED = "ARCHIVED",
+  DELETED = "DELETED"
 }
 
 registerEnumType(ProgramStatus, {

--- a/backend/src/entities/progressSession.ts
+++ b/backend/src/entities/progressSession.ts
@@ -38,6 +38,10 @@ export class ProgressSession extends BaseEntity {
 
   @Field()
   @Column({ default: false })
+  createConnect!: boolean;
+
+  @Field()
+  @Column({ default: false })
   searchProgram!: boolean;
 
   @Field(() => User)

--- a/backend/src/resolvers/programResolver.ts
+++ b/backend/src/resolvers/programResolver.ts
@@ -140,7 +140,8 @@ export class ProgramResolver {
   async deleteProgram(@Arg("id") id: string) {
     const program = await Program.findOneBy({ id });
     if (!program) throw new Error("Aucun programme n'a été trouvé");
-    program.remove();
+    program.status = ProgramStatus.DELETED;
+    await program.save();
     return "Le programme a bien été supprimé";
   }
 

--- a/backend/src/resolvers/studentResolver.ts
+++ b/backend/src/resolvers/studentResolver.ts
@@ -14,7 +14,7 @@ import isNotificationAllowed from "../services/notificationPreferenceService";
 import { NotificationType } from "../InputType/notificationType";
 import { createNotification } from "../services/notificationsService";
 import { Program } from "../entities/program";
-import { ProgramMarketplaceResponse } from "../InputType/programType";
+import { ProgramMarketplaceResponse, ProgramStatus } from "../InputType/programType";
 import { UserProgram, UserProgramStatus } from "../entities/userProgram";
 import { In, MoreThan } from "typeorm";
 import { stripe } from "../config/stripe";
@@ -209,6 +209,7 @@ export class StudentResolver {
     const programs = await Program.find({
       where: {
         public: true,
+        status: ProgramStatus.PUBLISHED,
         price: MoreThan(0),
       },
       relations: {

--- a/backend/src/services/progressService.ts
+++ b/backend/src/services/progressService.ts
@@ -1,6 +1,6 @@
 import { ProgressSession } from "../entities/progressSession";
 
-type Target = "profile" | "training" | "program" | "offer" | "searchProgram";
+type Target = "profile" | "training" | "program" | "offer" | "searchProgram" | "createConnect";
 
 export async function updateProgress(userId: string, target: Target) {
   const progress = await ProgressSession.findOne({

--- a/backend/src/webhook/handlers/handleAccountUpdated.ts
+++ b/backend/src/webhook/handlers/handleAccountUpdated.ts
@@ -1,11 +1,15 @@
 import Stripe from "stripe";
 import { CoachProfile } from "../../entities/coachProfile";
+import { updateProgress } from "../../services/progressService";
 
 // Handler pour déterminer si le compte coach peut recevoir et retirer des paiements
 export async function handleAccountUpdated(account: Stripe.Account) {
   try {
     const coachProfile = await CoachProfile.findOne({
       where: { stripeAccountId: account.id },
+      relations: {
+        user: true,
+      },
     });
 
     if (!coachProfile) {
@@ -23,6 +27,8 @@ export async function handleAccountUpdated(account: Stripe.Account) {
     }
     coachProfile.detailsSubmitted = account.details_submitted;
     coachProfile.detailsSubmitted = account.details_submitted;
+    if (coachProfile.user)
+      await updateProgress(coachProfile.user.id, "createConnect");
 
     await coachProfile.save();
     console.log(

--- a/frontend/src/graphql/hooks.tsx
+++ b/frontend/src/graphql/hooks.tsx
@@ -803,12 +803,14 @@ export type ProgramMarketplaceResponse = {
 /** Le statut d'un programme (brouillon, publié, archivé) */
 export enum ProgramStatus {
   Archived = 'ARCHIVED',
+  Deleted = 'DELETED',
   Draft = 'DRAFT',
   Published = 'PUBLISHED'
 }
 
 export type ProgressSession = {
   __typename?: 'ProgressSession';
+  createConnect: Scalars['Boolean']['output'];
   id: Scalars['ID']['output'];
   offer: Scalars['Boolean']['output'];
   profile: Scalars['Boolean']['output'];
@@ -1207,6 +1209,7 @@ export type User = {
   stripeCustomerId?: Maybe<Scalars['String']['output']>;
   studentOffer?: Maybe<Offer>;
   students?: Maybe<Array<User>>;
+  tokenVersion: Scalars['Float']['output'];
   trainings?: Maybe<Array<Training>>;
   userPrograms?: Maybe<Array<UserProgram>>;
 };
@@ -1838,7 +1841,7 @@ export type GetMyMembershipQuery = { __typename?: 'Query', getMembership: { __ty
 export type GetProgressQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetProgressQuery = { __typename?: 'Query', getProgress: { __typename?: 'ProgressSession', id: string, profile: boolean, training: boolean, program: boolean, offer: boolean, searchCoach: boolean, searchProgram: boolean } };
+export type GetProgressQuery = { __typename?: 'Query', getProgress: { __typename?: 'ProgressSession', id: string, profile: boolean, training: boolean, program: boolean, offer: boolean, searchCoach: boolean, searchProgram: boolean, createConnect: boolean } };
 
 export type GetInvoicesQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -4929,6 +4932,7 @@ export const GetProgressDocument = gql`
     offer
     searchCoach
     searchProgram
+    createConnect
   }
 }
     `;

--- a/frontend/src/pages/Home/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Home/Dashboard/Dashboard.tsx
@@ -127,7 +127,7 @@ export default function Dashboard({ currentUser }: DashboardProps) {
                   id: 4,
                   text: "Crée ton compte Connect",
                   action: () => navigate("/profile?tab=stripe"),
-                  completed: false,
+                  completed: progress?.createConnect ?? false,
                 },
                 {
                   id: 5,
@@ -170,9 +170,9 @@ export default function Dashboard({ currentUser }: DashboardProps) {
 
   return (
     <section className="w-full h-full flex flex-col justify-start items-center pb-8 overflow-y-auto gap-2">
-      <div className="w-full 2xl:max-w-[1700px] 2xl:min-w-[1000px] grid grid-rows-2 gap-2">
+      <div className="w-full 2xl:max-w-[1700px] 2xl:min-w-[1000px] flex flex-col items-center justify-start gap-2">
         <div className="grid grid-cols-2 gap-2">
-          <div className="flex-1 h-full p-4 bg-white border border-gray-100 rounded-xl shadow-sm">
+          <div className="h-full p-4 bg-white border border-gray-100 rounded-xl shadow-sm">
             <div className="w-full h-full p-6 flex flex-col items-center justify-center">
               <ProgressComponent
                 userName={currentUser?.firstname || ""}
@@ -184,7 +184,7 @@ export default function Dashboard({ currentUser }: DashboardProps) {
             <DashboardCaroussel items={carousselItems} />
           </div>
         </div>
-        <div className="flex flex-col gap-4 justify-start items-center p-4 bg-white border border-gray-100 rounded-xl shadow-sm">
+        <div className="w-full flex flex-col gap-4 justify-start items-center px-4 py-8 bg-white border border-gray-100 rounded-xl shadow-sm">
           <div className="flex justify-center items-center gap-2">
             <DateNavigator date={currentDate} setDate={setCurrentDate} />
           </div>

--- a/frontend/src/pages/Home/Program/Program.tsx
+++ b/frontend/src/pages/Home/Program/Program.tsx
@@ -180,7 +180,7 @@ export default function Program() {
   return (
     <section className="relative w-full h-full flex flex-col justify-start items-center bg-white rounded-2xl px-4 pt-10 gap-4">
       {!isConfiguration && (
-        <section className="w-full flex flex-col justify-start items-center rounded-2xl gap-4 pt-6 pb-4">
+        <section className="w-full h-full flex flex-col justify-start items-center rounded-2xl gap-4 pt-6 pb-4">
           <section className="w-[85%] flex justify-between items-center">
             <AnimatedWrapper
               animation="slideUp"

--- a/frontend/src/pages/Home/components/HomeSidebar.tsx
+++ b/frontend/src/pages/Home/components/HomeSidebar.tsx
@@ -203,7 +203,7 @@ export default function HomeSidebar() {
           ))}
         </div>
       </div>
-      <div className="pl-1 w-full">
+      <div className="w-full">
         <UserProfile open={open} />
       </div>
     </motion.section>

--- a/frontend/src/pages/Home/components/UserProfile.tsx
+++ b/frontend/src/pages/Home/components/UserProfile.tsx
@@ -19,7 +19,7 @@ export default function UserProfile({ open }: UserProfileProps) {
       color="foreground"
     >
       <section
-        className="hover:bg-gray-500 hover:bg-opacity-20 w-full cursor-pointer"
+        className="hover:bg-gray-500 hover:bg-opacity-20 w-full cursor-pointer pl-1"
         onClick={() => navigate("/profile?tab=informations")}
       >
         <section className="flex justify-between items-center p-2 w-full">

--- a/frontend/src/pages/Profile/components/Stripe/Stripe.tsx
+++ b/frontend/src/pages/Profile/components/Stripe/Stripe.tsx
@@ -17,12 +17,21 @@ export default function Stripe() {
     fetchPolicy: "cache-and-network",
   });
   const coachProfile = dataProfile?.getCoachProfile;
+  const gotStripeAccount = coachProfile?.stripeAccountId !== null;
+  const canSell = coachProfile?.chargesEnabled;
+  const canPayout = coachProfile?.payoutsEnabled;
+  const onboardingComplete = coachProfile?.detailsSubmitted;
+
   const handleCreatePortailStripe = async () => {
     try {
       const { data } = await getConnect();
       if (data?.getConnectUrl) {
         const connectUrl = data?.getConnectUrl;
-        window.open(connectUrl);
+        if (canSell && canPayout) {
+          window.open(connectUrl);
+        } else {
+          window.location.href = connectUrl;
+        }
       }
     } catch (error) {
       console.error(error);
@@ -31,10 +40,6 @@ export default function Stripe() {
       );
     }
   };
-  const gotStripeAccount = coachProfile?.stripeAccountId !== null;
-  const canSell = coachProfile?.chargesEnabled;
-  const canPayout = coachProfile?.payoutsEnabled;
-  const onboardingComplete = coachProfile?.detailsSubmitted;
   return (
     <AnimatedWrapper className="w-full h-full pb-4">
       <section className="w-full px-4">

--- a/frontend/src/queries/GetProgress.ts
+++ b/frontend/src/queries/GetProgress.ts
@@ -10,6 +10,7 @@ export const GET_PROGRESS = gql`
       offer
       searchCoach
       searchProgram
+      createConnect
     }
   }
 `;


### PR DESCRIPTION
✅ PR Title
feat(progress): enable Connect field + soft delete for programs + minor CSS fixes

📝 Description
Cette PR inclut plusieurs améliorations et correctifs mineurs dans le cadre du ticket QC-44-AddProgress :

Ajout d’un nouveau champ Connect dans le composant Progress :
Ce champ est activé lors de la création du compte Connect par l’utilisateur.

Mise en place du soft delete pour les entités Program :

Ajout d'un status Deleted sur les programmes.

Remplacement de la suppression physique par un soft delete logique pour conserver l’historique et la traçabilité.

Correctifs CSS divers :

Ajustements visuels pour améliorer la cohérence et le rendu de certains composants.

🔗 Ticket lié
[QC-44-AddProgress]

⚠️ Notes
PR mineure, sans breaking changes.

Aucune modification critique sur les flux existants.

Vérifier que le champ Connect est bien conditionné à la création du compte, et que les programmes supprimés ne s’affichent plus dans les listes standards.